### PR TITLE
Ensure the original response stream is restored

### DIFF
--- a/src/XperienceCommunity.CSP.csproj
+++ b/src/XperienceCommunity.CSP.csproj
@@ -9,7 +9,7 @@
 	<PropertyGroup>
 		<Title>Xperience by Kentico CSP Management</Title>
 		<PackageId>XperienceCommunity.CSP</PackageId>
-		<Version>2.2.0</Version>
+		<Version>2.2.1</Version>
 		<Authors>Liam Goldfinch</Authors>
 		<Company>Liam Goldfinch</Company>
 		<PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
When a site has other middleware potentially modifying the response, it could be short-ciruiting the response and causing the CSP middleware to error

Fixes #10 