### PR TITLE
fix: add permissions to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Add explicit permissions declaration to CI workflow for security best practices.

## Changes
- Added `permissions: contents: read` to `.github/workflows/ci.yml`
- Follows principle of least privilege by explicitly declaring minimal required permissions

## Rationale
GitHub Actions should declare explicit permissions rather than using default permissions. This improves security by limiting what the workflow can access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>